### PR TITLE
Address compilation issues when building on/for macOS

### DIFF
--- a/opencog/persist/cog-simple/CogSimpleStorage.cc
+++ b/opencog/persist/cog-simple/CogSimpleStorage.cc
@@ -133,11 +133,12 @@ void CogSimpleStorage::open(void)
 	rc = setsockopt(_sockfd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof(flags));
 	if (0 > rc)
 		fprintf(stderr, "Error setting sockopt: %s", strerror(errno));
+#ifndef __APPLE__
 	flags = 1;
 	rc = setsockopt(_sockfd, IPPROTO_TCP, TCP_QUICKACK, &flags, sizeof(flags));
 	if (0 > rc)
 		fprintf(stderr, "Error setting sockopt: %s", strerror(errno));
-
+#endif
 	// Get the s-expression shell.
 	std::string eval = "sexpr\n";
 

--- a/opencog/persist/cog-storage/CogChannel.cc
+++ b/opencog/persist/cog-storage/CogChannel.cc
@@ -67,7 +67,7 @@ void CogChannel<Client, Data>::open_connection(const std::string& uri)
 {
 #define URIX_LEN (sizeof("cog://") - 1)  // Should be 6
 	if (strncmp(uri.c_str(), "cog://", URIX_LEN))
-		throw IOException(TRACE_INFO, "Unknown URI '%s'\n", uri);
+		throw IOException(TRACE_INFO, "Unknown URI '%s'\n", uri.c_str());
 
 	_uri = uri;
 
@@ -132,11 +132,12 @@ int CogChannel<Client, Data>::open_sock()
 	rc = setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof(flags));
 	if (0 > rc)
 		fprintf(stderr, "Error setting sockopt: %s", strerror(errno));
+#ifndef __APPLE__
 	flags = 1;
 	rc = setsockopt(sockfd, IPPROTO_TCP, TCP_QUICKACK, &flags, sizeof(flags));
 	if (0 > rc)
 		fprintf(stderr, "Error setting sockopt: %s", strerror(errno));
-
+#endif
 	// Get the s-expression shell.
 	std::string eval = "sexpr\n";
 	rc = send(sockfd, eval.c_str(), eval.size(), 0);


### PR DESCRIPTION
Bypass application of TCP_QUICKACK  - as far as I can tell it isn't defined yet.
Also, explicitly convert a log argument to c_str, the implicit version is an error by default with clang.

Apologies if this is not the correct format for change requests - I just came across it locally so thought I'd share my changes, please abandon if so.

I used the macro ```__APPLE__``` as I think I came across that in some other atomspace code (I'm still new to OpenCog code), let me know if there is a better switch available and I can update.